### PR TITLE
chore: fix repo url to unblock npm publishing 

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -13,6 +13,7 @@ const project = new CdklabsConstructLibrary({
   cdkVersion: '2.0.0',
   defaultReleaseBranch: 'main',
   name: `@aws-cdk/asset-node-proxy-agent-v${SPEC_VERSION}`,
+  repository: 'https://github.com/cdklabs/awscdk-asset-node-proxy-agent.git',
   repositoryUrl: 'https://github.com/cdklabs/awscdk-asset-node-proxy-agent.git',
   homepage: 'https://github.com/cdklabs/awscdk-asset-node-proxy-agent#readme',
   majorVersion: 2,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws-cdk/asset-node-proxy-agent-v6",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aws/asset-node-proxy-agent-v6.git"
+    "url": "https://github.com/cdklabs/awscdk-asset-node-proxy-agent.git"
   },
   "scripts": {
     "build": "npx projen build",


### PR DESCRIPTION
Publishing is currently failing because the repository url in `package.json` doesn't match the repo name.