### PR TITLE
chore: integration test failed because of a new feature flag set to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.181.0",
     "cdklabs-projen-project-types": "^0.1.204",
     "commit-and-tag-version": "^12",
     "constructs": "^10.0.5",

--- a/test/integ.node-proxy-agent.ts
+++ b/test/integ.node-proxy-agent.ts
@@ -4,6 +4,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3_assets from 'aws-cdk-lib/aws-s3-assets';
 import * as cr from 'aws-cdk-lib/custom-resources';
+import { LAMBDA_CREATE_NEW_POLICIES_WITH_ADDTOROLEPOLICY } from 'aws-cdk-lib/cx-api';
 
 import { ASSET_FILE, LAYER_SOURCE_DIR } from '../lib';
 
@@ -11,7 +12,12 @@ import { ASSET_FILE, LAYER_SOURCE_DIR } from '../lib';
  * Test verifies that node-proxy-agent is invoked successfully inside Lambda runtime.
  */
 
-const app = new cdk.App();
+const app = new cdk.App({
+  postCliContext: {
+    [LAMBDA_CREATE_NEW_POLICIES_WITH_ADDTOROLEPOLICY]: false,
+  },
+});
+
 const stack = new cdk.Stack(app, 'lambda-layer-node-proxy-agent-integ-stack');
 const asset = new s3_assets.Asset(stack, 'node-proxy-asset', {
   path: ASSET_FILE,


### PR DESCRIPTION
This PR https://github.com/aws/aws-cdk/pull/33291 adding a new feature flag to update IAM policies. If the default value is false, it shouldn't have any changes.

However, in the integration tests run by CodeBuild, it's enabled for some reasons, leading to a failed integration test.